### PR TITLE
Improve Risk Details layout - Business Disruption section

### DIFF
--- a/frontend/src/pages/ViewRisk.tsx
+++ b/frontend/src/pages/ViewRisk.tsx
@@ -149,44 +149,47 @@ export const ViewRisk: React.FC = () => {
         </Grid>
 
         {/* Business Disruption Assessment */}
-        <Grid item xs={12} md={6}>
+        <Grid item xs={12}>
           <Card>
             <CardContent>
               <Typography variant="h6" gutterBottom>
                 Business Disruption Assessment
               </Typography>
-              <Box sx={{ mb: 2 }}>
-                <Typography variant="subtitle2">Impact Rating</Typography>
-                <Chip
-                  label={risk.business_disruption_impact_rating}
-                  color={risk.business_disruption_impact_rating === 'Catastrophic' ? 'error' :
-                         risk.business_disruption_impact_rating === 'Major' ? 'warning' :
-                         risk.business_disruption_impact_rating === 'Moderate' ? 'info' : 'success'}
-                  size="small"
-                  sx={{ mb: 1 }}
-                />
-                <Typography variant="body2">{risk.business_disruption_impact_description}</Typography>
-              </Box>
-              <Box sx={{ mb: 2 }}>
-                <Typography variant="subtitle2">Likelihood Rating</Typography>
-                <Chip
-                  label={risk.business_disruption_likelihood_rating}
-                  color={risk.business_disruption_likelihood_rating === 'Probable' ? 'error' :
-                         risk.business_disruption_likelihood_rating === 'Possible' ? 'warning' :
-                         risk.business_disruption_likelihood_rating === 'Unlikely' ? 'info' : 'success'}
-                  size="small"
-                  sx={{ mb: 1 }}
-                />
-                <Typography variant="body2">{risk.business_disruption_likelihood_description}</Typography>
-              </Box>
-              <Box>
-                <Typography variant="subtitle2">Net Exposure</Typography>
-                <Chip
-                  label={risk.business_disruption_net_exposure}
-                  color={getNetExposureColor(risk.business_disruption_net_exposure)}
-                  size="medium"
-                />
-              </Box>
+              <Grid container spacing={3}>
+                <Grid item xs={12} md={4}>
+                  <Typography variant="subtitle2">Impact Rating</Typography>
+                  <Chip
+                    label={risk.business_disruption_impact_rating}
+                    color={risk.business_disruption_impact_rating === 'Catastrophic' ? 'error' :
+                           risk.business_disruption_impact_rating === 'Major' ? 'warning' :
+                           risk.business_disruption_impact_rating === 'Moderate' ? 'info' : 'success'}
+                    size="small"
+                    sx={{ mb: 1 }}
+                  />
+                  <Typography variant="body2">{risk.business_disruption_impact_description}</Typography>
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <Typography variant="subtitle2">Likelihood Rating</Typography>
+                  <Chip
+                    label={risk.business_disruption_likelihood_rating}
+                    color={risk.business_disruption_likelihood_rating === 'Probable' ? 'error' :
+                           risk.business_disruption_likelihood_rating === 'Possible' ? 'warning' :
+                           risk.business_disruption_likelihood_rating === 'Unlikely' ? 'info' : 'success'}
+                    size="small"
+                    sx={{ mb: 1 }}
+                  />
+                  <Typography variant="body2">{risk.business_disruption_likelihood_description}</Typography>
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <Typography variant="subtitle2">Net Exposure</Typography>
+                  <Chip
+                    label={risk.business_disruption_net_exposure}
+                    color={getNetExposureColor(risk.business_disruption_net_exposure)}
+                    size="medium"
+                    sx={{ mb: 1 }}
+                  />
+                </Grid>
+              </Grid>
             </CardContent>
           </Card>
         </Grid>


### PR DESCRIPTION
## Summary

Refactored the Business Disruption Assessment section in the Risk Details view to use a horizontal full-width layout instead of a 2-column vertical layout.

### Changes Made
- **Business Disruption Assessment**: Changed from `xs={12} md={6}` to `xs={12}` (full-width)
- Added internal `Grid container` with 3 columns (`xs={12} md={4}`) for Impact, Likelihood, and Net Exposure
- Matches the styling pattern of the Control Assessment section for visual consistency
- Eliminates excessive white space below the Ownership & Management section

### Mobile Responsiveness
- On desktop: 3 columns side-by-side
- On mobile: Columns stack vertically for optimal readability

### Testing
- ✅ All 95 unit tests passing locally
- ✅ Pre-commit hooks passed
- ⏳ CI workflow will run automatically on this PR

### Visual Improvement
Before: Business Disruption and Ownership sections in 2-column layout with significant height mismatch
After: Business Disruption in horizontal strip format, better space utilization

🤖 Generated with [Claude Code](https://claude.com/claude-code)