### PR TITLE
fix: Correct --startup-cpu-boost to --cpu-boost flag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -314,7 +314,7 @@ jobs:
             --min-instances 0 \
             --max-instances 10 \
             --timeout=300 \
-            --startup-cpu-boost \
+            --cpu-boost \
             --cpu-throttling \
             --set-env-vars "GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }},ENVIRONMENT=production,ALLOWED_ORIGINS=*,DATABASE_URL=sqlite:///./risk_register.db,GCP_BUCKET_NAME=${{ secrets.GCP_PROJECT_ID }}-technology-risk-register-database,AUTH_USERNAME=admin,AUTH_PASSWORD=${{ secrets.AUTH_PASSWORD }},AUTH_SECRET_KEY=${{ secrets.AUTH_SECRET_KEY }},ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -240,7 +240,7 @@ gcloud run deploy technology-risk-register \
     --min-instances 0 \
     --max-instances 10 \
     --timeout=300 \
-    --startup-cpu-boost \
+    --cpu-boost \
     --cpu-throttling \
     --set-env-vars "$ENV_VARS"
 


### PR DESCRIPTION
## Problem
The previous PR merge reintroduced the wrong flag `--startup-cpu-boost` which doesn't exist.

Deployment was failing with:
```
ERROR: (gcloud.run.deploy) unrecognized arguments: --startup-cpu-boost (did you mean '--cpu-boost'?)
```

## Fix
Changed `--startup-cpu-boost` to `--cpu-boost` in both:
- `.github/workflows/cd.yml` (line 317)
- `deploy.sh` (line 243)

## Verification
```bash
✅ No 'startup-cpu-boost' found - all fixed!
```

This is a quick hotfix to unblock deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>